### PR TITLE
Support RFC3339 timestamp format

### DIFF
--- a/src/helper.rs
+++ b/src/helper.rs
@@ -287,6 +287,9 @@ pub fn parse_timestamp(value: &str) -> Result<OffsetDateTime> {
     let utc_format = format_description::parse(
         "[year][month][day]T[hour][minute][second]Z",
     )?;
+    let rfc3339_format = format_description::parse(
+        "[year]-[month]-[day]T[hour]:[minute]:[second]Z",
+    )?;
     let implicit_utc_format = format_description::parse(
         "[year][month][day]T[hour][minute][second]",
     )?;
@@ -298,6 +301,11 @@ pub fn parse_timestamp(value: &str) -> Result<OffsetDateTime> {
     {
         Ok(result)
     } else if let Ok(result) = PrimitiveDateTime::parse(value, &utc_format) {
+        let result = OffsetDateTime::now_utc().replace_date_time(result);
+        Ok(result)
+    } else if let Ok(result) =
+        PrimitiveDateTime::parse(value, &rfc3339_format)
+    {
         let result = OffsetDateTime::now_utc().replace_date_time(result);
         Ok(result)
     } else {

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -218,6 +218,9 @@ fn types_timestamp() -> Result<()> {
 
     let timestamp = parse_timestamp("19961022T140000-0500")?;
     assert_eq!("1996-10-22 14:00:00.0 -05:00:00", &timestamp.to_string());
+
+    let timestamp = parse_timestamp("1996-10-22T14:00:00Z")?;
+    assert_eq!("1996-10-22 14:00:00.0 +00:00:00", &timestamp.to_string());
     Ok(())
 }
 


### PR DESCRIPTION
While trying to parse my collection of vcard files with the library,
I stumbled upon a lot of them that have their REV property in RFC3339
format. I suspect they were created by an old iOS version at some
point and never actually modified after that.

They are still getting synced between various services just fine,
so support such timestamp formats in the library.
