### PR TITLE
Allow TYPE parameter on X- properties

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -298,6 +298,7 @@ impl<'s> VcardParser<'s> {
                             // Check this parameter is allowed
                             if !TYPE_PROPERTIES
                                 .contains(&&property_upper_name[..])
+                                && !property_upper_name.starts_with("X-")
                             {
                                 return Err(Error::TypeParameter(
                                     property_upper_name,


### PR DESCRIPTION
According to the spec, the TYPE parameter MUST not be applied on
properties defined in the spec, but not explicitly listed in section
5.6 of the RFC.

https://www.rfc-editor.org/rfc/rfc6350#section-5.6

This means that the parameter MAY be applied on properties not
explicitly listed in the spec, such as non-standard 'X-' properties.

The patch allows TYPE parameter on such properties.
