### PR TITLE
Allow redundant CHARSET=UTF-8 parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 
 Fast and correct vCard parser based on [RFC6350](https://www.rfc-editor.org/rfc/rfc6350); see the [API documentation](https://docs.rs/vcard4/latest/vcard4/) for more information.
 
+For interoperability with older software the parser will accept input with a `CHARSET` parameter that has a value of `UTF-8`, any other encoding value for `CHARSET` will generate an error. However, this parameter is not part of [RFC6350](https://www.rfc-editor.org/rfc/rfc6350) and is therefore not included in the string output for a vCard.
+
 License is MIT or Apache-2.0.

--- a/src/error.rs
+++ b/src/error.rs
@@ -184,4 +184,8 @@ pub enum Error {
     /// Error generated during lexing.
     #[error(transparent)]
     LexError(#[from] LexError),
+
+    /// Error generated when a CHARSET other than UTF-8 is specified.
+    #[error("CHARSET='{0}' is invalid, expected UTF-8")]
+    CharsetParameter(String),
 }

--- a/src/name.rs
+++ b/src/name.rs
@@ -58,6 +58,9 @@ pub(crate) const SORT_AS: &str = "SORT-AS";
 // NOTE: we use GEO from the property names
 // NOTE: we use TZ from the property names
 pub(crate) const LABEL: &str = "LABEL";
+// RFC 6350 removed the CHARSET parameter because it requires UTF-8, but some
+// implementations still emit CHARSET=UTF-8. This is the only value we allow.
+pub(crate) const CHARSET: &str = "CHARSET";
 
 // Apple uses this for embedded photos
 pub(crate) const ENCODING: &str = "ENCODING";

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -46,7 +46,7 @@ pub(crate) enum Token {
     #[token("\"")]
     DoubleQuote,
 
-    #[regex("(?i:LANGUAGE|VALUE|PREF|ALTID|PID|TYPE|MEDIATYPE|CALSCALE|SORT-AS|LABEL|ENCODING)")]
+    #[regex("(?i:LANGUAGE|VALUE|PREF|ALTID|PID|TYPE|MEDIATYPE|CALSCALE|SORT-AS|CHARSET|LABEL|ENCODING)")]
     ParameterKey,
 
     #[token("=")]
@@ -370,6 +370,13 @@ impl<'s> VcardParser<'s> {
                                         );
                                     }
                                 }
+                            }
+                        }
+                        CHARSET => {
+                            // Ignore CHARSET=UTF-8 for compatibility with software that
+                            // unnecessarily (and in spite of RFC 6350) adds this parameter.
+                            if value != "UTF-8" {
+                                return Err(Error::CharsetParameter(value));
                             }
                         }
                         LABEL => {


### PR DESCRIPTION
Allow (and ignore) `CHARSET=UTF-8` in the input, but omit it in the output. Any value other than `UTF-8` will still cause an error.

~@tmpfs I wasn't quite sure what to do about `parse_parameters` always returning a `Parameters` instance (which breaks `assert_round_trip()` when the only parameter is `CHARSET`), so I changed it to return a `Result<Option<Parameters>>`. This requires a rather unfortunate comparison with `Parameters::default()` though, so I am very much open to alternative suggestions.~

Fixes: https://github.com/tmpfs/vcard4/issues/16